### PR TITLE
feat(nodejs): Freshen up!

### DIFF
--- a/charts/nodejs/Chart.yaml
+++ b/charts/nodejs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Deploying NoodeJS applications to Kubernetes
 name: nodejs
-version: 0.1.0
+version: 0.2.0

--- a/charts/nodejs/templates/_helpers.tpl
+++ b/charts/nodejs/templates/_helpers.tpl
@@ -32,14 +32,53 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nodejs.appVersion" -}}
+{{- if .Values.appVersion }}
+{{- .Values.appVersion | quote -}}
+{{- else if .Values.image.tag }}
+{{- .Values.image.tag | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "nodejs.labels" -}}
 app.kubernetes.io/name: {{ include "nodejs.name" . }}
 helm.sh/chart: {{ include "nodejs.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
+app.kubernetes.io/name: {{ include "nodejs.name" . }}
+{{- if (and false .Chart.AppVersion) }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+{{- if include "nodejs.appVersion" . }}
+app.kubernetes.io/version: {{ include "nodejs.appVersion" . }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for Ingress objects.
+*/}}
+{{- define "nodejs.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return "true" if the API ingressClassName field is supported
+*/}}
+{{- define "nodejs.ingress.supportsIngressClassname" -}}
+{{- if semverCompare "<1.18-0" .Capabilities.KubeVersion.Version -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
 {{- end -}}

--- a/charts/nodejs/templates/configmap.yaml
+++ b/charts/nodejs/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.configuration }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,3 +8,4 @@ metadata:
 data:
   configuration: |
 {{ toJson .Values.configuration | indent 4 }}
+{{- end }}

--- a/charts/nodejs/templates/deployment.yaml
+++ b/charts/nodejs/templates/deployment.yaml
@@ -57,17 +57,25 @@ spec:
             {{- if .Values.environment }}
             {{- toYaml .Values.environment | nindent 12 }}
             {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
+          {{- end }}
           volumeMounts:
+            {{- if .Values.configuration }}
             - name: config
               mountPath: {{ .Values.applicationDirectory }}/config/production.json
               subPath: configuration
+            {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
       volumes:
+      {{- if .Values.configuration }}
       - name: config
         configMap:
           name: {{ include "nodejs.fullname" . }}
+      {{- end }}
       {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/nodejs/templates/ingress.yaml
+++ b/charts/nodejs/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "nodejs.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "nodejs.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -10,7 +10,13 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if and .Values.ingress.ingressClassName (eq "false" (include "nodejs.ingress.supportsIngressClassname" .)) }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
 spec:
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "nodejs.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -18,19 +24,25 @@ spec:
       {{- range .hosts }}
         - {{ . | quote }}
       {{- end }}
+      {{- if .secretName }}
       secretName: {{ .secretName }}
+      {{- end }}
   {{- end }}
 {{- end }}
   rules:
+  {{- $pathType := .Values.ingress.pathType -}}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ $pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/nodejs/values.yaml
+++ b/charts/nodejs/values.yaml
@@ -32,10 +32,13 @@ tls:
 ingress:
   # ingress.enabled -- Whether to enable ingress to the application.
   enabled: false
+  # ingress.ingressClassName -- Which ingressClass to assign this ingress to.
+  ingressClassName: nginx
   # ingress.annotations -- Annotations to apply to the ingress.
-  annotations:
-    kubernetes.io/ingress.class: nginx
+  annotations: {}
     # kubernetes.io/tls-acme: "true"
+  # ingress.pathType -- https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+  pathType: Prefix
   # ingress.hosts -- Host and path configurations to route to the service
   hosts:
     # ingress.hosts[0].host -- An example hostname.
@@ -56,6 +59,8 @@ healthCheckUrl: /health-check
 configuration: {}
 # environment -- Environment variables to set inside the containers.
 environment: []
+# envFrom -- Environment variables from ConfigMaps/Secrets to import into the containers.
+envFrom: []
 # resources -- Resource requests/limits for the deployment.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Add support for:
* ALB controller (via `ingressClassName` & `pathType`)
* `envFrom` list (e.g., to reference external/existing secrets)
* multiple Ingress versions; sorta: `serviceName` v `service.name`