### PR TITLE
feat/lrsql-add-postgres-backend

### DIFF
--- a/charts/lrsql/Chart.lock
+++ b/charts/lrsql/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.2
-digest: sha256:420de1bdf252f4ec099e063136e472ff341a0f096a54ed2eb2ab4ff979179f2d
-generated: "2024-06-13T13:23:29.241966-06:00"
+  version: 2.22.0
+- name: postgresql
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 15.5.29
+digest: sha256:ec8f290ccbc6e77fabe27d9ee88de56af456849f6495943b4dc58ce526c2c502
+generated: "2024-09-12T21:45:43.621698-04:00"

--- a/charts/lrsql/Chart.yaml
+++ b/charts/lrsql/Chart.yaml
@@ -28,3 +28,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x
+  - condition: postgres.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 15.X.X

--- a/charts/lrsql/Chart.yaml
+++ b/charts/lrsql/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x
-  - condition: postgres.enabled
+  - condition: postgresql.enabled
     name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 15.X.X

--- a/charts/lrsql/templates/deployment.yaml
+++ b/charts/lrsql/templates/deployment.yaml
@@ -34,17 +34,19 @@ spec:
           image: {{ include "lrsql.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           # TODO: This should go somewhere else
-          {{- if not (or (.Values.sqlite.enabled) (.Values.postgres.enabled)) }}
-          {{- fail ".Values.sqlite.enabled or .Values.postgres.enabled must be enabled" }}
+          {{- if not (or (.Values.sqlite.enabled) (.Values.postgresql.enabled)) }}
+          {{- fail ".Values.sqlite.enabled or .Values.postgresql.enabled must be enabled" }}
           {{- end }}
           # TODO: This should go somewhere else
-          {{- if and (.Values.sqlite.enabled) (.Values.postgres.enabled) }}
-          {{- fail ".Values.sqlite.enabled and .Values.postgres.enabled cannot both be true" }}
+          {{- if and (.Values.sqlite.enabled) (.Values.postgresql.enabled) }}
+          {{- fail ".Values.sqlite.enabled and .Values.postgresql.enabled cannot both be true" }}
           {{- end }}
-          {{- if and (.Values.sqlite.enabled) (.Values.sqlite.command) }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.sqlite.command "context" $) | nindent 12 }}
-          {{- else if and (.Values.postgres.enabled) (.Values.postgres.command) }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.postgres.command "context" $) | nindent 12 }}
+          {{- if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- else if .Values.sqlite.enabled }}
+          command: ["/lrsql/bin/run_sqlite.sh"]
+          {{- else if .Values.postgresql.enabled }}
+          command: ["/lrsql/bin/run_postgres.sh"]
           {{- end }}
           {{- if .Values.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
@@ -61,10 +63,20 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-            {{- if and (.Values.sqlite.enabled) (.Values.sqlite.extraEnvVars) }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.sqlite.extraEnvVars "context" $) | nindent 12 }}
-            {{- else if and (.Values.postgres.enabled) (.Values.postgres.extraEnvVars) }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.postgres.extraEnvVars "context" $) | nindent 12 }}
+            {{- if .Values.sqlite.enabled }}
+            - name: LRSQL_DB_NAME
+              value: {{ .Values.postgresql.auth.database }}
+            {{- else if .Values.postgresql.enabled }}
+            - name: LRSQL_DB_NAME
+              value: {{ .Values.postgresql.auth.database }}
+            - name: LRSQL_DB_HOST
+              value: {{ .Values.postgresql.lrsql.dbHost }}
+            - name: LRSQL_DB_PORT
+              value: {{ .Values.postgresql.lrsql.dbPort | quote }}
+            - name: LRSQL_DB_USER
+              value: {{ .Values.postgresql.auth.username }}
+            - name: LRSQL_DB_PASSWORD
+              value: {{ .Values.postgresql.auth.password }}
             {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}

--- a/charts/lrsql/templates/deployment.yaml
+++ b/charts/lrsql/templates/deployment.yaml
@@ -33,8 +33,18 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "lrsql.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.command }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          # TODO: This should go somewhere else
+          {{- if not (or (.Values.sqlite.enabled) (.Values.postgres.enabled)) }}
+          {{- fail ".Values.sqlite.enabled or .Values.postgres.enabled must be enabled" }}
+          {{- end }}
+          # TODO: This should go somewhere else
+          {{- if and (.Values.sqlite.enabled) (.Values.postgres.enabled) }}
+          {{- fail ".Values.sqlite.enabled and .Values.postgres.enabled cannot both be true" }}
+          {{- end }}
+          {{- if and (.Values.sqlite.enabled) (.Values.sqlite.command) }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.sqlite.command "context" $) | nindent 12 }}
+          {{- else if and (.Values.postgres.enabled) (.Values.postgres.command) }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.postgres.command "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
@@ -50,6 +60,11 @@ spec:
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+            {{- if and (.Values.sqlite.enabled) (.Values.sqlite.extraEnvVars) }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.sqlite.extraEnvVars "context" $) | nindent 12 }}
+            {{- else if and (.Values.postgres.enabled) (.Values.postgres.extraEnvVars) }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.postgres.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}

--- a/charts/lrsql/values.yaml
+++ b/charts/lrsql/values.yaml
@@ -13,86 +13,35 @@ image:
   pullSecrets: []
   debug: false
 
+## Command and args for running the container (set to default if not set). Use array form
+## @param postgres.command Override default container command (useful when using custom images) ie. ["/lrsql/bin/run_postgres.sh"]
+## @param postgres.args Override default container args (useful when using custom images)
+##
+command: []
+args: []
 
 sqlite:
   enabled: true
-  ## Command and args for running the container (set to default if not set). Use array form
-  ## @param sqlite.command Override default container command (useful when using custom images) ie. ["/lrsql/bin/run_postgres.sh"]
-  ## @param sqlite.args Override default container args (useful when using custom images)
-  ##
-  command: ["/lrsql/bin/run_sqlite.sh"]
-  args: []
-  ## @param sqlite.extraEnvVars Extra environment variables to be set on NGINX containers
-  ## E.g:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: BAR
-  ##
-  extraEnvVars:
-    - name: LRSQL_DB_NAME
-      value: "db/lrsql.sqlite.db"
-    - name: LRSQL_ALLOW_ALL_ORIGINS
-      value: "true"
-    - name: LRSQL_ADMIN_USER_DEFAULT
-      value: admin
-    - name: LRSQL_ADMIN_PASS_DEFAULT
-      value: admin
-    - name: LRSQL_API_KEY_DEFAULT
-      value: my_key
-    - name: LRSQL_API_SECRET_DEFAULT
-      value: my_secret
+  lrsql:
+    dbName: db/lrsql.sqlite.db
 
-
-postgres:
+# TODO: this is clunky and needs a new home.
+# we also want to either set the env vars based on this
+# or set these based on the env vars.
+# The actual values for the postgres dependancy are mixed in here
+postgresql:
   enabled: false
-  ## Command and args for running the container (set to default if not set). Use array form
-  ## @param postgres.command Override default container command (useful when using custom images) ie. ["/lrsql/bin/run_postgres.sh"]
-  ## @param postgres.args Override default container args (useful when using custom images)
-  ##
-  command: ["/lrsql/bin/run_postgres.sh"]
-  ## @param postgres.extraEnvVars Extra environment variables to be set on NGINX containers
-  ## E.g:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: BAR
-  ##
-  extraEnvVars:
-    - name: LRSQL_DB_NAME
-      value: "lrsql_db"
-    # TODO: REMOVE ME END POSTGRES
-    # TODO: this should be pg hostname yeah?
-    - name: LRSQL_DB_HOST
-      value: lrsql-postgresql
-    - name: LRSQL_DB_PORT
-      value: "5432"
-    - name: LRSQL_DB_USER
-      value: lrsql_user
-    - name: LRSQL_DB_PASSWORD
-      value: lrsql_password
-    # TODO: REMOVE ME END POSTGRES
-    - name: LRSQL_ALLOW_ALL_ORIGINS
-      value: "true"
-    - name: LRSQL_ADMIN_USER_DEFAULT
-      value: admin
-    - name: LRSQL_ADMIN_PASS_DEFAULT
-      value: admin
-    - name: LRSQL_API_KEY_DEFAULT
-      value: my_key
-    - name: LRSQL_API_SECRET_DEFAULT
-      value: my_secret
-
-  # TODO: this is clunky and needs a new home.
-  # we also want to either set the env vars based on this
-  # or set these based on the env vars.
-  postgresql:
-    auth:
-      enablePostgresUser: true
-      postgresPassword: lrsql
-      username: lrsql_user
-      password: lrsql_password
-      database: lrsql_db
-      existingSecret: ""
-    architecture: standalone
+  auth:
+    enablePostgresUser: true
+    postgresPassword: lrsql
+    username: lrsql_user
+    password: lrsql_password
+    database: lrsql_db
+    existingSecret: ""
+  architecture: standalone
+  lrsql:
+    dbHost: lrsql-postgresql
+    dbPort: 5432
 
 
 ## @param extraEnvVars Extra environment variables to be set on NGINX containers
@@ -101,7 +50,17 @@ postgres:
 ##   - name: FOO
 ##     value: BAR
 ##
-extraEnvVars: ""
+extraEnvVars:
+  - name: LRSQL_ALLOW_ALL_ORIGINS
+    value: "true"
+  - name: LRSQL_ADMIN_USER_DEFAULT
+    value: admin
+  - name: LRSQL_ADMIN_PASS_DEFAULT
+    value: admin
+  - name: LRSQL_API_KEY_DEFAULT
+    value: my_key
+  - name: LRSQL_API_SECRET_DEFAULT
+    value: my_secret
 ## @param extraEnvVarsCM ConfigMap with extra environment variables
 ##
 extraEnvVarsCM: ""

--- a/charts/lrsql/values.yaml
+++ b/charts/lrsql/values.yaml
@@ -13,31 +13,95 @@ image:
   pullSecrets: []
   debug: false
 
-## Command and args for running the container (set to default if not set). Use array form
-## @param command Override default container command (useful when using custom images) ie. ["/lrsql/bin/run_postgres.sh"]
-## @param args Override default container args (useful when using custom images)
-##
-command: ["/lrsql/bin/run_sqlite.sh"]
-args: []
+
+sqlite:
+  enabled: true
+  ## Command and args for running the container (set to default if not set). Use array form
+  ## @param sqlite.command Override default container command (useful when using custom images) ie. ["/lrsql/bin/run_postgres.sh"]
+  ## @param sqlite.args Override default container args (useful when using custom images)
+  ##
+  command: ["/lrsql/bin/run_sqlite.sh"]
+  args: []
+  ## @param sqlite.extraEnvVars Extra environment variables to be set on NGINX containers
+  ## E.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: BAR
+  ##
+  extraEnvVars:
+    - name: LRSQL_DB_NAME
+      value: "db/lrsql.sqlite.db"
+    - name: LRSQL_ALLOW_ALL_ORIGINS
+      value: "true"
+    - name: LRSQL_ADMIN_USER_DEFAULT
+      value: admin
+    - name: LRSQL_ADMIN_PASS_DEFAULT
+      value: admin
+    - name: LRSQL_API_KEY_DEFAULT
+      value: my_key
+    - name: LRSQL_API_SECRET_DEFAULT
+      value: my_secret
+
+
+postgres:
+  enabled: false
+  ## Command and args for running the container (set to default if not set). Use array form
+  ## @param postgres.command Override default container command (useful when using custom images) ie. ["/lrsql/bin/run_postgres.sh"]
+  ## @param postgres.args Override default container args (useful when using custom images)
+  ##
+  command: ["/lrsql/bin/run_postgres.sh"]
+  ## @param postgres.extraEnvVars Extra environment variables to be set on NGINX containers
+  ## E.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: BAR
+  ##
+  extraEnvVars:
+    - name: LRSQL_DB_NAME
+      value: "lrsql_db"
+    # TODO: REMOVE ME END POSTGRES
+    # TODO: this should be pg hostname yeah?
+    - name: LRSQL_DB_HOST
+      value: lrsql-postgresql
+    - name: LRSQL_DB_PORT
+      value: "5432"
+    - name: LRSQL_DB_USER
+      value: lrsql_user
+    - name: LRSQL_DB_PASSWORD
+      value: lrsql_password
+    # TODO: REMOVE ME END POSTGRES
+    - name: LRSQL_ALLOW_ALL_ORIGINS
+      value: "true"
+    - name: LRSQL_ADMIN_USER_DEFAULT
+      value: admin
+    - name: LRSQL_ADMIN_PASS_DEFAULT
+      value: admin
+    - name: LRSQL_API_KEY_DEFAULT
+      value: my_key
+    - name: LRSQL_API_SECRET_DEFAULT
+      value: my_secret
+
+  # TODO: this is clunky and needs a new home.
+  # we also want to either set the env vars based on this
+  # or set these based on the env vars.
+  postgresql:
+    auth:
+      enablePostgresUser: true
+      postgresPassword: lrsql
+      username: lrsql_user
+      password: lrsql_password
+      database: lrsql_db
+      existingSecret: ""
+    architecture: standalone
+
+
 ## @param extraEnvVars Extra environment variables to be set on NGINX containers
 ## E.g:
 ## extraEnvVars:
 ##   - name: FOO
 ##     value: BAR
 ##
-extraEnvVars:
-  - name: LRSQL_DB_NAME
-    value: "db/lrsql.sqlite.db"
-  - name: LRSQL_ALLOW_ALL_ORIGINS
-    value: "true"
-  - name: LRSQL_ADMIN_USER_DEFAULT
-    value: admin
-  - name: LRSQL_ADMIN_PASS_DEFAULT
-    value: admin
-  - name: LRSQL_API_KEY_DEFAULT
-    value: my_key
-  - name: LRSQL_API_SECRET_DEFAULT
-    value: my_secret
+extraEnvVars: ""
 ## @param extraEnvVarsCM ConfigMap with extra environment variables
 ##
 extraEnvVarsCM: ""


### PR DESCRIPTION
DRAFT. IN PROGRESS.

Adds prototype support for enabling postgres or sqlite as a backend. hardcoded passwords and all with no pvc backing postgres. This just runs and the UI can be logged in to.