### PR TITLE
feat: add `openldap` chart, forked from deprecated `helm/charts`

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -9,5 +9,6 @@
   "charts/mutating-webhook": "0.2.0",
   "charts/nodejs": "0.3.1",
   "charts/pachyderm": "0.3.0",
-  "charts/postgrest": "0.4.0"
+  "charts/postgrest": "0.4.0",
+  "charts/openldap": "1.2.6"
 }

--- a/charts/openldap/.helmignore
+++ b/charts/openldap/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/openldap/Chart.yaml
+++ b/charts/openldap/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: openldap
+type: application
+# home: https://www.openldap.org
+version: 1.2.6
+appVersion: 2.4.48
+description: This chart was forked from the now-deprecated Helm Charts repository.
+icon: http://www.openldap.org/images/headers/LDAPworm.gif
+keywords:
+  - ldap
+  - openldap
+sources:
+  - https://github.com/helm/charts

--- a/charts/openldap/README.md
+++ b/charts/openldap/README.md
@@ -1,0 +1,50 @@
+# openldap
+
+### version: 1.2.6<!-- x-release-please-version -->
+
+![AppVersion: 2.4.48](https://img.shields.io/badge/AppVersion-2.4.48-informational?style=flat-square)
+
+This chart was forked from the now-deprecated Helm Charts repository.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| env.LDAP_BACKEND | string | `"hdb"` |  |
+| env.LDAP_DOMAIN | string | `"example.org"` |  |
+| env.LDAP_ORGANISATION | string | `"Example Inc."` |  |
+| env.LDAP_REMOVE_CONFIG_AFTER_SETUP | string | `"true"` |  |
+| env.LDAP_TLS | string | `"true"` |  |
+| env.LDAP_TLS_ENFORCE | string | `"false"` |  |
+| existingSecret | string | `""` |  |
+| extraLabels | object | `{}` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"osixia/openldap"` |  |
+| image.tag | string | `"1.2.4"` |  |
+| initResources | object | `{}` |  |
+| logLevel | string | `"info"` |  |
+| nodeSelector | object | `{}` |  |
+| persistence.accessMode | string | `"ReadWriteOnce"` |  |
+| persistence.enabled | bool | `false` |  |
+| persistence.size | string | `"8Gi"` |  |
+| podAnnotations | object | `{}` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| service.annotations | object | `{}` |  |
+| service.externalIPs | list | `[]` |  |
+| service.ldapPort | int | `389` |  |
+| service.loadBalancerIP | string | `""` |  |
+| service.loadBalancerSourceRanges | list | `[]` |  |
+| service.sslLdapPort | int | `636` |  |
+| service.type | string | `"ClusterIP"` |  |
+| strategy | object | `{}` |  |
+| test.enabled | bool | `false` |  |
+| test.image.repository | string | `"dduportal/bats"` |  |
+| test.image.tag | string | `"0.4.0"` |  |
+| tls.CA.enabled | bool | `false` |  |
+| tls.CA.secret | string | `""` |  |
+| tls.enabled | bool | `false` |  |
+| tls.secret | string | `""` |  |
+| tolerations | list | `[]` |  |
+

--- a/charts/openldap/README.md.gotmpl
+++ b/charts/openldap/README.md.gotmpl
@@ -1,0 +1,15 @@
+{{ template "chart.header" . }}
+
+### version: {{ template "chart.version" . }}<!-- x-release-please-version -->
+
+{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/openldap/templates/NOTES.txt
+++ b/charts/openldap/templates/NOTES.txt
@@ -1,0 +1,20 @@
+OpenLDAP has been installed. You can access the server from within the k8s cluster using:
+
+  {{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ldapPort }}
+
+
+You can access the LDAP adminPassword and configPassword using:
+
+  kubectl get secret --namespace {{ .Release.Namespace }} {{ template "openldap.secretName" . }} -o jsonpath="{.data.LDAP_ADMIN_PASSWORD}" | base64 --decode; echo
+  kubectl get secret --namespace {{ .Release.Namespace }} {{ template "openldap.secretName" . }} -o jsonpath="{.data.LDAP_CONFIG_PASSWORD}" | base64 --decode; echo
+
+
+You can access the LDAP service, from within the cluster (or with kubectl port-forward) with a command like (replace password and domain):
+  ldapsearch -x -H ldap://{{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ldapPort }} -b dc=example,dc=org -D "cn=admin,dc=example,dc=org" -w $LDAP_ADMIN_PASSWORD
+
+
+Test server health using Helm test:
+  helm test {{ .Release.Name }}
+
+
+You can also consider installing the helm chart for phpldapadmin to manage this instance of OpenLDAP, or install Apache Directory Studio, and connect using kubectl port-forward.

--- a/charts/openldap/templates/_helpers.tpl
+++ b/charts/openldap/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openldap.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "openldap.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openldap.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Generate chart secret name
+*/}}
+{{- define "openldap.secretName" -}}
+{{ default (include "openldap.fullname" .) .Values.existingSecret }}
+{{- end -}}

--- a/charts/openldap/templates/configmap-customldif.yaml
+++ b/charts/openldap/templates/configmap-customldif.yaml
@@ -1,0 +1,23 @@
+#
+# A ConfigMap spec for openldap slapd that map directly to files under
+# /container/service/slapd/assets/config/bootstrap/ldif/custom
+#
+{{- if .Values.customLdifFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openldap.fullname" . }}-customldif
+  labels:
+    app: {{ template "openldap.name" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+data:
+{{- range $key, $val := .Values.customLdifFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end }}

--- a/charts/openldap/templates/configmap-env.yaml
+++ b/charts/openldap/templates/configmap-env.yaml
@@ -1,0 +1,20 @@
+#
+# A ConfigMap spec for openldap slapd that map directly to env variables in the Pod.
+# List of environment variables supported is from the docker image:
+# https://github.com/osixia/docker-openldap#beginner-guide
+# Note that passwords are defined as secrets
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openldap.fullname" . }}-env
+  labels:
+    app: {{ template "openldap.name" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+data:
+{{ toYaml .Values.env | indent 2 }}

--- a/charts/openldap/templates/deployment.yaml
+++ b/charts/openldap/templates/deployment.yaml
@@ -1,0 +1,177 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  {{ template "openldap.fullname" . }}
+  labels:
+    app: {{ template "openldap.name" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+{{- if .Values.strategy }}
+  strategy:
+{{ toYaml .Values.strategy | indent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "openldap.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env: {{ include (print $.Template.BasePath "/configmap-env.yaml") . | sha256sum }}
+{{- if .Values.customLdifFiles}}
+        checksum/configmap-customldif: {{ include (print $.Template.BasePath "/configmap-customldif.yaml") . | sha256sum }}
+{{- end }}
+{{- if .Values.podAnnotations}}
+{{ toYaml .Values.podAnnotations | indent 8}}
+{{- end }}
+      labels:
+        app: {{ template "openldap.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      {{- if or .Values.customLdifFiles .Values.tls.enabled }}
+      initContainers:
+      {{- end }}
+      {{- if .Values.customLdifFiles }}
+      - name: {{ .Chart.Name }}-init-ldif
+        image: busybox
+        command: ['sh', '-c', 'cp /customldif/* /ldifworkingdir']
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+        - name: customldif
+          mountPath: /customldif
+        - name: ldifworkingdir
+          mountPath: /ldifworkingdir
+        resources:
+{{ toYaml .Values.initResources | indent 10 }}
+      {{- end }}
+      {{- if .Values.tls.enabled }}
+      - name: {{ .Chart.Name }}-init-tls
+        image: busybox
+        command: ['sh', '-c', 'cp /tls/* /certs']
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+          - name: tls
+            mountPath: /tls
+          - name: certs
+            mountPath: /certs
+        resources:
+{{ toYaml .Values.initResources | indent 10 }}
+      {{- if .Values.tls.CA.enabled }}
+      - name: {{ .Chart.Name }}-init-catls
+        image: busybox
+        command: ['sh', '-c', 'cp /catls/ca.crt /certs']
+        volumeMounts:
+          - name: catls
+            mountPath: /catls
+          - name: certs
+            mountPath: /certs
+        resources:
+{{ toYaml .Values.initResources | indent 10 }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -l
+            - {{ .Values.logLevel }}
+{{- if .Values.customLdifFiles }}
+            - --copy-service
+{{- end }}
+          ports:
+            - name: ldap-port
+              containerPort: 389
+            - name: ssl-ldap-port
+              containerPort: 636
+          envFrom:
+            - configMapRef:
+                name: {{ template "openldap.fullname" . }}-env
+            - secretRef:
+                name: {{ template "openldap.secretName" . }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/ldap
+              subPath: data
+            - name: data
+              mountPath: /etc/ldap/slapd.d
+              subPath: config-data
+            {{- if .Values.customLdifFiles }}
+            - name: ldifworkingdir
+              mountPath: /container/service/slapd/assets/config/bootstrap/ldif/custom
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: certs
+              mountPath: /container/service/slapd/assets/certs
+            {{- end }}
+          env:
+          {{- if .Values.tls.enabled }}
+            - name: LDAP_TLS_CRT_FILENAME
+              value: tls.crt
+            - name: LDAP_TLS_KEY_FILENAME
+              value: tls.key
+          {{- if .Values.tls.CA.enabled }}
+            - name: LDAP_TLS_CA_CRT_FILENAME
+              value: ca.crt
+          {{- end }}
+          {{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: ldap-port
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          readinessProbe:
+            tcpSocket:
+              port: ldap-port
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+        {{- if .Values.customLdifFiles }}
+        - name: customldif
+          configMap:
+            name: {{ template "openldap.fullname" . }}-customldif
+        - name: ldifworkingdir
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.secret }}
+        {{- if .Values.tls.CA.enabled }}
+        - name: catls
+          secret:
+            secretName: {{ .Values.tls.CA.secret }}
+        {{- end }}
+        {{- end }}
+        - name: certs
+          emptyDir:
+            medium: Memory
+        - name: data
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "openldap.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end -}}

--- a/charts/openldap/templates/pvc.yaml
+++ b/charts/openldap/templates/pvc.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "openldap.fullname" . }}
+  labels:
+    app: {{ template "openldap.name" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openldap/templates/secret.yaml
+++ b/charts/openldap/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{ if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "openldap.fullname" . }}
+  labels:
+    app: {{ template "openldap.name" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+type: Opaque
+data:
+  LDAP_ADMIN_PASSWORD: {{ .Values.adminPassword | default (randAlphaNum 32) | b64enc | quote }}
+  LDAP_CONFIG_PASSWORD: {{ .Values.configPassword | default (randAlphaNum 32) | b64enc | quote }}
+{{ end }}

--- a/charts/openldap/templates/service.yaml
+++ b/charts/openldap/templates/service.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  name: {{ template "openldap.fullname" . }}
+  labels:
+    app: {{ template "openldap.name" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+spec:
+  {{- with .Values.service.clusterIP }}
+  clusterIP: {{ . | quote }}
+  {{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: ldap-port
+      protocol: TCP
+      port: {{ .Values.service.ldapPort }}
+      targetPort: ldap-port
+    - name: ssl-ldap-port
+      protocol: TCP
+      port: {{ .Values.service.sslLdapPort }}
+      targetPort: ssl-ldap-port
+  selector:
+    app: {{ template "openldap.name" . }}
+    release: {{ .Release.Name }}
+  type: {{ .Values.service.type }}

--- a/charts/openldap/templates/tests/openldap-test-runner.yaml
+++ b/charts/openldap/templates/tests/openldap-test-runner.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.test.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "openldap.fullname" . }}-test-{{ randAlphaNum 5 | lower }}"
+  labels:
+    app: {{ template "openldap.name" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  initContainers:
+    - name: test-framework
+      image: {{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}
+      command:
+        - "bash"
+        - "-c"
+        - |
+          set -ex
+          # copy bats to tools dir
+          cp -R /usr/local/libexec/ /tools/bats/
+      volumeMounts:
+        - mountPath: /tools
+          name: tools
+  containers:
+    - name: {{ .Release.Name }}-test
+      image: {{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}
+      envFrom:
+        - secretRef:
+            name: {{ template "openldap.secretName" . }}
+      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      volumeMounts:
+        - mountPath: /tests
+          name: tests
+          readOnly: true
+        - mountPath: /tools
+          name: tools
+  volumes:
+    - name: tests
+      configMap:
+        name: {{ template "openldap.fullname" . }}-tests
+    - name: tools
+      emptyDir: {}
+  restartPolicy: Never
+{{- end -}}

--- a/charts/openldap/templates/tests/openldap-tests.yaml
+++ b/charts/openldap/templates/tests/openldap-tests.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.test.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openldap.fullname" . }}-tests
+  labels:
+    app: {{ template "openldap.name" . }}
+    chart: {{ template "openldap.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+data:
+  run.sh: |-
+    @test "Testing connecting to slapd server" {
+      # Ideally, this should be in the docker image, but there is not a generic image we can use
+      # with bats and ldap-utils installed. It is not worth for now to push an image for this.
+      apt-get update && apt-get install -y ldap-utils
+      ldapsearch -x -H ldap://{{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ldapPort }} -b "dc=example,dc=org" -D "cn=admin,dc=example,dc=org" -w $LDAP_ADMIN_PASSWORD
+    }
+{{- end -}}

--- a/charts/openldap/values.yaml
+++ b/charts/openldap/values.yaml
@@ -1,0 +1,120 @@
+# Default values for openldap.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+# Define deployment strategy - IMPORTANT: use rollingUpdate: null when use Recreate strategy.
+# It prevents from merging with existing map keys which are forbidden.
+strategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+  #
+  # or
+  #
+  # type: Recreate
+  # rollingUpdate: null
+image:
+  # From repository https://github.com/osixia/docker-openldap
+  repository: osixia/openldap
+  tag: 1.2.4
+  pullPolicy: IfNotPresent
+
+# Spcifies an existing secret to be used for admin and config user passwords
+existingSecret: ""
+
+# settings for enabling TLS
+tls:
+  enabled: false
+  secret: ""  # The name of a kubernetes.io/tls type secret to use for TLS
+  CA:
+    enabled: false
+    secret: ""  # The name of a generic secret to use for custom CA certificate (ca.crt)
+## Add additional labels to all resources
+extraLabels: {}
+## Add additional annotations to pods
+podAnnotations: {}
+service:
+  annotations: {}
+
+  ldapPort: 389
+  sslLdapPort: 636  # Only used if tls.enabled is true
+  ## List of IP addresses at which the service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  type: ClusterIP
+
+# Default configuration for openldap as environment variables. These get injected directly in the container.
+# Use the env variables from https://github.com/osixia/docker-openldap#beginner-guide
+env:
+  LDAP_ORGANISATION: "Example Inc."
+  LDAP_DOMAIN: "example.org"
+  LDAP_BACKEND: "hdb"
+  LDAP_TLS: "true"
+  LDAP_TLS_ENFORCE: "false"
+  LDAP_REMOVE_CONFIG_AFTER_SETUP: "true"
+
+# Default Passwords to use, stored as a secret. If unset, passwords are auto-generated.
+# You can override these at install time with
+# helm install openldap --set openldap.adminPassword=<passwd>,openldap.configPassword=<passwd>
+# adminPassword: admin
+# configPassword: config
+
+# Custom openldap configuration files used to override default settings
+# customLdifFiles:
+  # 01-default-users.ldif: |-
+    # Predefine users here
+
+## Persist data to a persistent volume
+persistence:
+  enabled: false
+  ## database data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 8Gi
+  # existingClaim: ""
+
+resources: {}
+ # requests:
+ #   cpu: "100m"
+ #   memory: "256Mi"
+ # limits:
+ #   cpu: "500m"
+ #   memory: "512Mi"
+
+initResources: {}
+ # requests:
+ #   cpu: "100m"
+ #   memory: "128Mi"
+ # limits:
+ #   cpu: "100m"
+ #   memory: "128Mi"
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+## test container details
+test:
+  enabled: false
+  image:
+    repository: dduportal/bats
+    tag: 0.4.0
+
+# Set the container log level
+# Valid log levels: none, error, warning, info (default), debug, trace
+logLevel: info

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -33,6 +33,9 @@
     "charts/nodejs": {
       "extra-files": ["README.md"]
     },
+    "charts/openldap": {
+      "extra-files": ["README.md"]
+    },
     "charts/pachyderm": {
       "extra-files": ["README.md"]
     },


### PR DESCRIPTION
This chart is used in the kind setup in `uki-dev/od360`, and may be used in UKI's cloud environments (to replace FreeIPA). 
