### PR TITLE
fix: trigger release-please patch release

### DIFF
--- a/charts/postgrest/Chart.yaml
+++ b/charts/postgrest/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.5.0
 maintainers:
   - name: jared-prime
     email: jared.davis@pelo.tech
-description: Helm chart for a PostgREST data api
+description: Helm chart for a PostgREST data api.
 
 dependencies:
   - name: cluster

--- a/charts/postgrest/README.md
+++ b/charts/postgrest/README.md
@@ -2,7 +2,7 @@
 
 ### version: 0.5.0<!-- x-release-please-version -->
 
-Helm chart for a PostgREST data api
+Helm chart for a PostgREST data api.
 
 ## Requirements
 
@@ -91,3 +91,4 @@ Helm chart for a PostgREST data api
 | keyserver.jwt.origin | string | `"https://jwt.io,https://app.localhost"` |  |
 | keyserver.jwt.trust | string | `"https://sso.localhost/auth/realms/example/protocol/openid-connect/certs"` |  |
 | keyserver.tag | string | `"latest"` |  |
+

--- a/charts/postgrest/README.md
+++ b/charts/postgrest/README.md
@@ -91,4 +91,3 @@ Helm chart for a PostgREST data api
 | keyserver.jwt.origin | string | `"https://jwt.io,https://app.localhost"` |  |
 | keyserver.jwt.trust | string | `"https://sso.localhost/auth/realms/example/protocol/openid-connect/certs"` |  |
 | keyserver.tag | string | `"latest"` |  |
-


### PR DESCRIPTION
Making a nearly empty change to trigger a patch chart release of postgrest so that release-please can publish it properly.