### PR TITLE
fix(postgrest): tag images with commit hash

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - fix/postgrest-tag
     tags:
       - "images/v*.*.*"
 
@@ -41,7 +40,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.image }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=${{ github.sha }},enable=${{ github.ref == format('refs/heads/{0}', 'fix/postgrest-tag') }}
+            type=raw,value=${{ github.sha }},enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{version}}
       - uses: docker/build-push-action@v6

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - feat/postgrest
+      - fix/postgrest-tag
     tags:
       - "images/v*.*.*"
 
@@ -41,7 +41,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.image }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'feat/postgrest') }}
+            type=raw,value=${{ github.sha }},enable=${{ github.ref == format('refs/heads/{0}', 'fix/postgrest-tag') }}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{version}}
       - uses: docker/build-push-action@v6

--- a/charts/postgrest/Chart.yaml
+++ b/charts/postgrest/Chart.yaml
@@ -5,6 +5,8 @@ version: 0.5.1
 maintainers:
   - name: jared-prime
     email: jared.davis@pelo.tech
+  - name: apkatsikas
+    email: andrew.katsikas@pelo.tech
 description: Helm chart for a PostgREST data api.
 
 dependencies:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
+![docker](https://github.com/pelotech/charts/actions/workflows/docker.yaml/badge.svg)
+![pr-title](https://github.com/pelotech/charts/actions/workflows/pr-title.yaml/badge.svg)
 ![pre-commit](https://github.com/pelotech/charts/actions/workflows/pre-commit.yaml/badge.svg)
-![helm charts](https://github.com/pelotech/charts/actions/workflows/main.yaml/badge.svg)
+![release-please](https://github.com/pelotech/charts/actions/workflows/release-please.yaml/badge.svg)
 
 # Pelotech Charts
 
@@ -11,5 +13,5 @@
 
 ## Contributing
 
-* We're staring to add the use of [pre-commit](https://pre-commit.com/)
+* We're starting to add the use of [pre-commit](https://pre-commit.com/)
 * `pre-commit run -a` to run - we'll eventually add the pre-commit hooks to run on commit


### PR DESCRIPTION
Updates the docker workflow to create a tag using the `github.sha`, so users can pull that specific version rather than `latest`.

Tested this image - https://github.com/pelotech/charts/pkgs/container/images%2Fkeyserver/683707920?tag=9dab0e8f22da4e482111876c1b469e295084e125 via this commit.