### PR TITLE
fix(postgrest): make PGRST_JWT_SUB optional in keyserver ConfigMap

### DIFF
--- a/charts/postgrest/README.md
+++ b/charts/postgrest/README.md
@@ -90,6 +90,7 @@ Helm chart for a PostgREST data api.
 | keyserver.jwt.iss | string | `"https://auth.app.localhost"` |  |
 | keyserver.jwt.jwks_uri | string | `"https://auth.app.localhost/jwks"` |  |
 | keyserver.jwt.origin | string | `"https://jwt.io,https://app.localhost"` |  |
+| keyserver.jwt.sub | string | `""` |  |
 | keyserver.jwt.trust | string | `"https://sso.localhost/auth/realms/example/protocol/openid-connect/certs"` |  |
 | keyserver.tag | string | `"latest"` |  |
 

--- a/charts/postgrest/templates/configurations.yaml
+++ b/charts/postgrest/templates/configurations.yaml
@@ -17,7 +17,9 @@ data:
   PGRST_JWT_ALG: {{ .Values.keyserver.jwt.alg | quote }}
   PGRST_JWT_ISS: {{ .Values.keyserver.jwt.iss | quote }}
   PGRST_JWT_EXP: {{ .Values.keyserver.jwt.exp | quote }}
+  {{- if .Values.keyserver.jwt.sub }}
   PGRST_JWT_SUB: {{ .Values.keyserver.jwt.sub | quote }}
+  {{- end }}
   PGRST_CLIENT_ORIGIN: {{ .Values.keyserver.jwt.origin | quote }}
   PGRST_JWK_TRUST: {{ .Values.keyserver.jwt.trust | quote }}
   PGRST_JWT_CLAIMS: {{ .Values.keyserver.jwt.claims | toJson | quote }}

--- a/charts/postgrest/values.yaml
+++ b/charts/postgrest/values.yaml
@@ -96,6 +96,7 @@ keyserver:
     origin: https://jwt.io,https://app.localhost
     trust: https://sso.localhost/auth/realms/example/protocol/openid-connect/certs
     jwks_uri: https://auth.app.localhost/jwks
+    sub: ''
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary
- Added `sub: ''` default to `values.yaml` so the key is always defined
- Conditionally render `PGRST_JWT_SUB` in the ConfigMap — omit it when blank rather than rendering an empty string

When `jwt.sub` is unset, the rendered ConfigMap contains `PGRST_JWT_SUB: ''`, which causes persistent out-of-sync state in Argo CD since the live resource never has this key set.