### PR TITLE
feat: allow configurable postgrest migrations command

### DIFF
--- a/charts/postgrest/README.md
+++ b/charts/postgrest/README.md
@@ -58,6 +58,8 @@ Helm chart for a PostgREST data api.
 | database.connection.hostname | string | `"postgrest-cluster-rw"` |  |
 | database.connection.password | string | `"postgrest"` |  |
 | database.connection.username | string | `"postgrest"` |  |
+| database.migrations.command[0] | string | `"/bin/goose"` |  |
+| database.migrations.command[1] | string | `"up"` |  |
 | database.migrations.database | string | `"postgrest"` |  |
 | database.migrations.enabled | bool | `false` |  |
 | database.migrations.hostname | string | `"postgrest-cluster-rw"` |  |

--- a/charts/postgrest/templates/deployment.yaml
+++ b/charts/postgrest/templates/deployment.yaml
@@ -69,8 +69,7 @@ spec:
           image: {{ .Values.database.migrations.image }}:{{ .Values.database.migrations.tag }}
           imagePullPolicy: IfNotPresent
           command:
-            - /bin/goose
-            - up
+          {{- toYaml .Values.database.migrations.command | nindent 12 }}
           {{- if .Values.database.migrations.loadFromConfigMap }}
           volumeMounts:
             - name: migrations

--- a/charts/postgrest/values.yaml
+++ b/charts/postgrest/values.yaml
@@ -24,6 +24,9 @@ database:
     tag: latest
     enabled: false
     loadFromConfigMap: false
+    command:
+      - /bin/goose
+      - up
 
 cluster:
   enabled: true


### PR DESCRIPTION
Allow configurable command on the charts/postgrest migrations init container so that alternate images can be used w/o a direct dependence on goose.